### PR TITLE
Chirp feature/joyce/bamboo 50/create post service

### DIFF
--- a/Chirp/src/app/core/models/chirrup.ts
+++ b/Chirp/src/app/core/models/chirrup.ts
@@ -1,32 +1,32 @@
 
 export interface Chirrup {
-    _id: string;
-    publisherName: string;
+    _id?: string;
+    publisherName?: string;
     content?: Content;
     publishedTime: string;
     comment: Comment[];
     likedIdList: LikedId[];
-    __v: number;
-    islike: boolean;
-    showComments: boolean;
+    __v?: number;
+    islike?: boolean;
+    showComments?: boolean;
 
 }
 
 interface Content {
-    image: string;
-    video: string;
+    image?: string;
+    video?: string;
     text: string;
-    _id: string;
+    _id?: string; // for post service
 }
 
 interface Comment {
-    _id: string;
-    publisherName?: string;  // Optional because not all comments have a publisherName
+    _id?: string;
+    publisherName?: string;
     content?: Content;
     publishedTime: string;
 }
 
 interface LikedId {
     userId: string;
-    _id: string;
+    _id?: string;
 }

--- a/Chirp/src/app/features/chirrup/chirrup.module.ts
+++ b/Chirp/src/app/features/chirrup/chirrup.module.ts
@@ -8,7 +8,7 @@ import { HomePageComponent } from './pages/home-page/home-page.component';
 import { LikedPageComponent } from './pages/liked-page/liked-page.component';
 import { ButtonModule } from 'primeng/button';
 import { SharedModule } from '../../shared/shared.module';
-
+import { ReactiveFormsModule } from '@angular/forms';
 
 
 @NgModule({
@@ -24,6 +24,7 @@ import { SharedModule } from '../../shared/shared.module';
     UserRoutingModule,
     ButtonModule,
     SharedModule,
+    ReactiveFormsModule,
 
   ],
   exports: [

--- a/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.html
+++ b/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.html
@@ -1,23 +1,27 @@
-<div class="new-chirrup">
+<div class="new-chirrup" [formGroup]="chirrupForm">
     <header>
         <div class="avatar">
             <img src="https://p1.itc.cn/q_70/images03/20221110/066590f43af14f9fa7bde4b1b0259266.png">
         </div>
         <div class="input-container">
             <i class="pi pi-pencil"></i>
-            <input type="text" placeholder="Share something......">
+            <input type="text" formControlName="text" placeholder="Share something......">
         </div>
     </header>
 
     <footer>
         <div class="add-on">
-            <p-button icon="pi pi-image"></p-button>
-            <p-button icon="pi pi-video"></p-button>
+            <input type="file" (change)="uploadImage($event)" hidden #imageInput>
+            <p-button icon="pi pi-image" (onClick)="imageInput.click()"></p-button>
+
+            <input type="file" (change)="uploadVideo($event)" hidden #videoInput>
+            <p-button icon="pi pi-video" (onClick)="videoInput.click()"></p-button>
+
             <p-button icon="pi pi-map-marker"></p-button>
         </div>
 
         <div class="post-button">
-            <p-button>post</p-button>
+            <p-button (onClick)="postChirrup()">post </p-button>
         </div>
 
     </footer>

--- a/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
+++ b/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
@@ -18,28 +18,14 @@ export class NewChirrupComponent {
       video: ['']
     });
   }
+
+
   uploadImage(event: any): void {
-    const file = event.target.files[0];
-    if (file) {
-      // Assuming you want to convert the image file to a Base64 URL
-      const reader = new FileReader();
-      reader.onload = (e: any) => {
-        this.chirrupForm.patchValue({ image: e.target.result });
-      };
-      reader.readAsDataURL(file);
-    }
+
   }
 
   uploadVideo(event: any): void {
-    const file = event.target.files[0];
-    if (file) {
-      // convert the video file to a Base64 URL
-      const reader = new FileReader();
-      reader.onload = (e: any) => {
-        this.chirrupForm.patchValue({ video: e.target.result });
-      };
-      reader.readAsDataURL(file);
-    }
+
   }
 
   postChirrup() {

--- a/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
+++ b/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
@@ -1,15 +1,83 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { PostService } from '../../services/post.service';
+
 
 @Component({
   selector: 'app-new-chirrup',
   templateUrl: './new-chirrup.component.html',
   styleUrls: ['./new-chirrup.component.sass']
 })
-export class NewChirrupComponent implements OnInit {
+export class NewChirrupComponent {
+  chirrupForm: FormGroup;
 
-  constructor() { }
-
-  ngOnInit(): void {
+  constructor(private fb: FormBuilder, private PostService: PostService) {
+    this.chirrupForm = this.fb.group({
+      text: ['', Validators.required],
+      image: [''],
+      video: ['']
+    });
+  }
+  uploadImage(event: any): void {
+    const file = event.target.files[0];
+    if (file) {
+      // Assuming you want to convert the image file to a Base64 URL
+      const reader = new FileReader();
+      reader.onload = (e: any) => {
+        this.chirrupForm.patchValue({ image: e.target.result });
+      };
+      reader.readAsDataURL(file);
+    }
   }
 
+  uploadVideo(event: any): void {
+    const file = event.target.files[0];
+    if (file) {
+      // convert the video file to a Base64 URL
+      const reader = new FileReader();
+      reader.onload = (e: any) => {
+        this.chirrupForm.patchValue({ video: e.target.result });
+      };
+      reader.readAsDataURL(file);
+    }
+  }
+
+  postChirrup() {
+    const formData = this.chirrupForm.value;
+    // const newChirrup = {
+    //   publisherName: 'Felix',
+    //   content: {
+    //     image: formData.image,
+    //     video: formData.video,
+    //     text: formData.text,
+    //   },
+    //   publishedTime: new Date().toISOString(),
+    //   comment: [],
+    //   likedIdList: [],
+    // }
+    const newChirrup = {
+      "publisherName": "Felix",
+      "content": {
+        "image": "formData.image",
+        "video": "formData.video",
+        "text": formData.text
+      },
+      "publishedTime": "2024-05-03T12:34:56.789Z",
+      "comment": [],
+      "likedIdList": []
+    }
+
+
+    // const chirrup1 = {
+    //   "content": { "image": "http://via.placeholder.com/640x360", "video": " ", "text": "I have posted a new chirrup", },
+    // }
+
+
+
+
+    this.PostService.postChirrup(newChirrup).subscribe({
+      next: response => console.log('Chirrup posted successfully!', response),
+      error: error => console.error('Failed to post chirrup:', error)
+    });
+  }
 }

--- a/Chirp/src/app/features/chirrup/services/post.service.spec.ts
+++ b/Chirp/src/app/features/chirrup/services/post.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PostService } from './post.service';
+
+describe('PostService', () => {
+  let service: PostService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PostService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Chirp/src/app/features/chirrup/services/post.service.ts
+++ b/Chirp/src/app/features/chirrup/services/post.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { catchError, Observable } from 'rxjs';
+import { Chirrup } from 'src/app/core/models/chirrup';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PostService {
+
+  private apiUrl: string = "http://localhost:4231/api/news";
+
+  constructor(private http: HttpClient) { }
+
+
+  postChirrup(chirrup: Chirrup): Observable<any> {
+    console.log('Posting this chirrup:', chirrup);
+    return this.http.post(this.apiUrl, chirrup).pipe(
+      catchError(error => {
+        throw 'Error posting story: ' + error.message;
+      })
+    );
+  }
+
+}


### PR DESCRIPTION
1. run backend
2. run frontend
3. type anything in new-chirrup input field and refresh page to see the new post **at the end of** the home page
4. You should be able to see sth like this:
<img width="486" alt="Screenshot 2024-05-02 at 12 46 50 PM" src="https://github.com/jingyued/Redpandas/assets/113967795/fff8ed8b-0d5f-499b-8cf0-aeb02b557f05">

Note: 
I push this for Yuri's reference when she works on the comment service cuz the logic are quite similar. I will keep modifying its UI as follows later today:
- Arrange posts in chronological order, show new post on the top
- Automatically refresh page, clean input box content, and provide a prompt after successful post new chirrup.)