### PR TITLE
use observable<Chirrup> to display new chirrup from the front end

### DIFF
--- a/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.sass
+++ b/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.sass
@@ -27,9 +27,6 @@
       border-radius: 50%
       object-fit: cover
 
-  .input-container 
-    display:flex
-    align-items: flex-start
 
   .input-container i 
     margin-top: 0

--- a/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
+++ b/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
@@ -12,8 +12,7 @@ import { Chirrup } from '../../../../core/models/chirrup';
 })
 export class NewChirrupComponent {
   chirrupForm: FormGroup;
-  private loginSubscription: any;
-  isLogin: boolean = false;
+  isLogin: boolean | undefined;
 
   constructor(
     private fb: FormBuilder,
@@ -27,7 +26,7 @@ export class NewChirrupComponent {
       video: ['']
     });
 
-    this.loginSubscription = this.auth.loginStatus.subscribe(update => {
+    this.auth.loginStatus.subscribe(update => {
       this.isLogin = update;
     })
   }
@@ -37,7 +36,7 @@ export class NewChirrupComponent {
     const currName = localStorage.getItem('userName');
 
     const newChirrup = {
-      publisherName: (currName === null) ? '' : currName,
+      publisherName: (currName === null || !this.isLogin) ? '' : currName,
       content: {
         // image: "image not available",
         // video: "video not available",

--- a/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
+++ b/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { PostService } from '../../services/post.service';
 import { SharedService } from '../../services/shared.service';
 import { AuthService } from 'src/app/shared/services/auth.service';
+import { Chirrup } from '../../../../core/models/chirrup';
 
 @Component({
   selector: 'app-new-chirrup',
@@ -49,10 +50,8 @@ export class NewChirrupComponent {
 
 
     this.PostService.postChirrup(newChirrup).subscribe({
-      next: () => {
-        // 发送成功后通知 chirrup-list 组件刷新
-        this.sharedService.notifyChirrupListRefresh();
-        // 清空表单
+      next: (chirrup: Chirrup) => {
+        this.sharedService.emitChirrup(newChirrup);
         this.chirrupForm.reset();
         alert("you have successfully posted a new chirrup!");
       },

--- a/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
+++ b/Chirp/src/app/features/chirrup/components/new-chirrup/new-chirrup.component.ts
@@ -35,7 +35,7 @@ export class NewChirrupComponent {
     const formData = this.chirrupForm.value;
     const currName = localStorage.getItem('userName');
 
-    const newChirrup = {
+    const newChirrup: Chirrup = {
       publisherName: (currName === null || !this.isLogin) ? '' : currName,
       content: {
         // image: "image not available",

--- a/Chirp/src/app/features/chirrup/services/shared.service.ts
+++ b/Chirp/src/app/features/chirrup/services/shared.service.ts
@@ -7,11 +7,16 @@ import { Chirrup } from '../../../core/models/chirrup';
 })
 export class SharedService {
   private chirrupSubject = new Subject<Chirrup>();
-
+  /**
+   * Notify any component subscribed this service for change
+   */
   emitChirrup(chirrup: Chirrup) {
     this.chirrupSubject.next(chirrup);
   }
-
+  /**
+   * Get an observable to subscribe in order to receive broadcast of notification
+   * @returns Observable<Chirrup>
+   */
   getChirrupListRefreshNotifier(): Observable<Chirrup> {
     return this.chirrupSubject.asObservable();
   }

--- a/Chirp/src/app/features/chirrup/services/shared.service.ts
+++ b/Chirp/src/app/features/chirrup/services/shared.service.ts
@@ -1,19 +1,18 @@
 import { Injectable } from '@angular/core';
 import { Subject, Observable } from 'rxjs';
+import { Chirrup } from '../../../core/models/chirrup';
 
 @Injectable({
   providedIn: 'root'
 })
 export class SharedService {
-  private newChirrupSubject = new Subject<void>();
+  private chirrupSubject = new Subject<Chirrup>();
 
-  // 用于通知 chirrup-list 刷新的方法
-  notifyChirrupListRefresh(): void {
-    this.newChirrupSubject.next();
+  emitChirrup(chirrup: Chirrup) {
+    this.chirrupSubject.next(chirrup);
   }
 
-  // 获取一个 Observable，用于 chirrup-list 监听通知
-  getChirrupListRefreshNotifier(): Observable<void> {
-    return this.newChirrupSubject.asObservable();
+  getChirrupListRefreshNotifier(): Observable<Chirrup> {
+    return this.chirrupSubject.asObservable();
   }
 }

--- a/Chirp/src/app/shared/components/chirrup-list/chirrup-list.component.ts
+++ b/Chirp/src/app/shared/components/chirrup-list/chirrup-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { GetChirrupsService } from '../../services/get-chirrups.service';
-import { Chirrup, Comment, Content } from '../../../core/models/chirrup';
+import { Chirrup, Comment } from '../../../core/models/chirrup';
 import { CommentService } from 'src/app/features/chirrup/services/comment.service';
 import { SharedService } from 'src/app/features/chirrup/services/shared.service';
 
@@ -36,20 +36,18 @@ export class ChirrupListComponent implements OnInit, OnDestroy {
   }
 
 
-  loadChirrups() {
+  loadChirrups(): void {
     this.getChirrupsService.getNews().subscribe({
       next: (data: Chirrup[]) => {
 
         this.news = data.map((item: Chirrup) => {
-          let isLiked = false; // 默认isLiked为false
+          let isLiked = false;
           if (item._id !== undefined) {
             const storedIsLiked = localStorage.getItem(item._id);
-            isLiked = storedIsLiked === 'true'; // 如果storedIsLiked为'true'，则isLiked为true
+            isLiked = storedIsLiked === 'true';
             if (storedIsLiked != null) {
-              console.log(isLiked)
             }
           }
-          console.log(isLiked)
           return {
             ...item,
             islike: isLiked,

--- a/Chirp/src/app/shared/components/chirrup-list/chirrup-list.component.ts
+++ b/Chirp/src/app/shared/components/chirrup-list/chirrup-list.component.ts
@@ -23,9 +23,11 @@ export class ChirrupListComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.loadChirrups();
-    // 订阅共享服务的刷新通知
-    this.refreshSubscription = this.sharedService.getChirrupListRefreshNotifier().subscribe(() => {
-      this.loadChirrups(); // 收到通知后刷新数据
+
+    this.refreshSubscription = this.sharedService.getChirrupListRefreshNotifier().subscribe(chirrup => {
+      // chirrup.publishedTime = "just now";
+      console.log(chirrup)
+      this.news = [chirrup, ...this.news];
     });
   }
 


### PR DESCRIPTION
- for the post-new-chirrup service, our original design is to first, post it in the back-end using a service, and notify the chirrup-list to re-fetch new data get from backend. So we don’t include any data, only need to inform subscribers that this event has happened. But this will have some latency if we always fetch data from backend.

- another way of doing this is to just emit the new chirrup and chirrup-list will listen to it and add it to the chirrups we get from the backend and stored in the front-end when initialized. The benefit of doing so is that change is immediately reflected in the view.

the difference between void and undefine:
1. Observable<void>:The subscribers to this observable are only interested in the fact that an event occurred.
2. Observable<undefined> / <null>: used on situations where an expected value is missing or, deliberately been set to a clear state.